### PR TITLE
fix(rebar3): compile failed on multiple-user host

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
 
 {escript_name, rebar3}.
 {escript_wrappers_windows, ["cmd", "powershell"]}.
-{escript_comment, "%%Rebar3 3.14.3-emqx-8"}.
+{escript_comment, "%%Rebar3 3.14.3-emqx-9"}.
 {escript_emu_args, "%%! +sbtu +A1\n"}.
 %% escript_incl_extra is for internal rebar-private use only.
 %% Do not use outside rebar. Config interface is not stable.

--- a/src/rebar_config.erl
+++ b/src/rebar_config.erl
@@ -465,7 +465,7 @@ generate_and_compile(ModuleFile) ->
     ModuleName = module_name(ModuleFile),
     ErlCode = rewrite_module_attribute(ErlCode0, ModuleName),
     TmpModName = iolist_to_binary([ModuleName, ".erl"]),
-    TmpModFile = filename:join([rebar_file_utils:system_tmpdir(), TmpModName]),
+    TmpModFile = filename:join([rebar_tmp_dir(), TmpModName]),
     ok = filelib:ensure_dir(TmpModFile),
     ok = file:write_file(TmpModFile, ErlCode),
     CompileOpts = [verbose,report_errors,report_warnings,return_errors,binary],
@@ -480,3 +480,5 @@ generate_and_compile(ModuleFile) ->
 
 rewrite_module_attribute(ErlCode, ModuleName) ->
     re:replace(ErlCode, "-module(.+)", ["-module('", ModuleName ,"')."]).
+
+rebar_tmp_dir() -> ".rebar".


### PR DESCRIPTION
On a multiple-user host, the `rebar3 compile` failed due to no access permission to `/tmp/rebar.config.erl`:

```
{15:01}~/code/emqx:delete_data_bridge_config ✗ ➭ ./rebar3 dialyzer
===> Uncaught error in rebar_core. Run with DIAGNOSTIC=1 to see stacktrace or consult rebar3.crashdump
===> When submitting a bug report, please include the output of `rebar3 report "your command"`
{15:02}~/code/emqx:delete_data_bridge_config ✗ ➭ head rebar3.crashdump
Error: {badmatch,{error,eacces}}
[{rebar_config,generate_and_compile,1,[{file,"rebar_config.erl"},{line,470}]},
 {rebar_config,compile_and_run,2,[{file,"rebar_config.erl"},{line,454}]},
 {rebar_config,consult_file,1,[{file,"rebar_config.erl"},{line,245}]},
 {rebar3,init_config,0,[{file,"rebar3.erl"},{line,206}]},
 {rebar3,run,1,[{file,"rebar3.erl"},{line,100}]},
 {rebar3,main,1,[{file,"rebar3.erl"},{line,66}]},
 {escript,run,2,[{file,"escript.erl"},{line,758}]},
 {escript,start,1,[{file,"escript.erl"},{line,277}]}]
```

As the `/tmp/rebar.config.erl` has no write permission to other users:

```
{15:51}~/code/emqx:delete_data_bridge_config ✓ ➭ ll /tmp/rebar.config.erl
-rw-r--r-- 1 shawn users 17K Jun 16 15:19 /tmp/rebar.config.erl
```