### PR TITLE
feat: add git repo dependency cache

### DIFF
--- a/.github/workflows/build_and_upload.yaml
+++ b/.github/workflows/build_and_upload.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: build
       run: |
         git config --global --add safe.directory $(pwd)
-        ./bootstrap
+        ./build
     - name: Create Release
       uses: softprops/action-gh-release@v1
       if: github.event_name == 'push' || inputs.create_release

--- a/build
+++ b/build
@@ -28,7 +28,7 @@ erl -noshell -eval "${CHECK_VSN}"
 
 if [ "${1:-}" = "--in-docker" ]; then
     #shellcheck disable=SC2086
-    exec docker run $maybeit --rm -v "$(pwd):/src" --workdir /src erlang:24 git config --global --add safe.directory /src && ./build
+    exec docker run $maybeit --rm -v "$(pwd):/src" --workdir /src erlang:25 git config --global --add safe.directory /src && ./build
 fi
 
 ./bootstrap

--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
 
 {escript_name, rebar3}.
 {escript_wrappers_windows, ["cmd", "powershell"]}.
-{escript_comment, "%%Rebar3 3.19.0-emqx-2"}.
+{escript_comment, "%%Rebar3 3.19.0-emqx-7"}.
 {escript_emu_args, "%%! +sbtu +A1\n"}.
 %% escript_incl_priv is for internal rebar-private use only.
 %% Do not use outside rebar. Config interface is not stable.

--- a/src/rebar_git_subdir_resource.erl
+++ b/src/rebar_git_subdir_resource.erl
@@ -66,6 +66,9 @@ to_ref(Rev) ->
 sparse_checkout(Name, GitVsn, Dir, Ref, SparseDir) when GitVsn >= {1,7,4};
                                                         GitVsn =:= undefined  ->
     ?DEBUG("doing sparse checkout in ~s of dir ~s", [Dir, SparseDir]),
+    %% Disable sparse-checkout before check_directory
+    %% in case it has been sparse-checkout before
+    rebar_utils:sh(?FMT("git sparse-checkout disable", []), [{cd, Dir}]),
     check_directory(Name, Dir, SparseDir),
     rebar_utils:sh(?FMT("git --git-dir=.git config core.sparsecheckout true", []),
                    [{cd, Dir}]),


### PR DESCRIPTION
Added two environment variables:
1. `REBAR_GIT_CACHE_DIR`: no default value, set to e.g. `/home/myname/.cache/rebar3/git` to keep the git clones cached
2. `REBAR_GIT_CACHE_REF_AUTOFILL`, default is `0`. Set it to any value other than `0` to automatically fill the cache if missed

If cache is hit, the git clone is done with options added: `--reference /path/to/cache/reponame --dissociate ` 
So the cached repo can be used to avoid running git clones, but git would still need to fetch.