### PR TITLE
fix(git): Unshallow repo before --reference clone

### DIFF
--- a/src/rebar_git_resource.erl
+++ b/src/rebar_git_resource.erl
@@ -241,9 +241,9 @@ git_clone2(tag, GitVsn, Url, Dir, Tag) ->
             ok = CloneF();
         {hit, RefDir} ->
             %% cache hit, reference-clone from the cache
-            ?DEBUG("Git reference-cache hit: ~ts", [RefDir]),
             try
-                ok = git_clone_ref(RefDir, CloneF)
+                ok = git_clone_ref(RefDir, CloneF),
+                ?INFO("Git reference-cache hit: ~ts", [RefDir])
             catch
                 _ : _ ->
                     ?WARN("Failed to --reference clone ~ts", [Url]),


### PR DESCRIPTION
Prior to this change, the reference repo is unshallowed after cache auto fill.
In case the unshallow command is aborted, it will fail the reference clones.
This commit makes rebar3 try to unshallow the repo before performing --reference clone.

Also, if reference clone failed, it fallbacks to the regular clone.