### PR TITLE
feat: make unicode as the printable range

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
 {escript_name, rebar3}.
 {escript_wrappers_windows, ["cmd", "powershell"]}.
 {escript_comment, "%%Rebar3 3.20.0-emqx-3"}.
-{escript_emu_args, "%%! +sbtu +A1\n"}.
+{escript_emu_args, "%%! +pc unicode +sbtu +A1\n"}.
 %% escript_incl_priv is for internal rebar-private use only.
 %% Do not use outside rebar. Config interface is not stable.
 {escript_incl_priv, [{relx, "templates/*"},


### PR DESCRIPTION
To avoiding formatting binaries with non-latin1 characters such as  `<<"test中文"/utf8>>` as `<<116,101,115,116,228,184,173,230,150,135>>`.