### PR TITLE
fix: add {middlebox_comp_mode, false} to ssl options when fetching deps

### DIFF
--- a/build
+++ b/build
@@ -18,7 +18,7 @@ case Vsn =:= "%%Rebar3 ${VERSION}" of
     false ->
         io:format("version mismatch in rebar.config\n"),
         io:format("escript_comment: " ++ Vsn ++ "\n"),
-        io:format("git descrite: ${VERSION}"),
+        io:format("git describe: ${VERSION}"),
         halt(1)
 end.
 EOF

--- a/src/rebar_utils.erl
+++ b/src/rebar_utils.erl
@@ -1078,7 +1078,8 @@ ssl_opts(ssl_verify_enabled, Url) ->
                          [{check_hostname, Hostname}]},
             CACerts = get_cacerts(),
             SslOpts = [{verify, verify_peer}, {depth, 2}, {cacerts, CACerts},
-                       {partial_chain, fun partial_chain/1}, {verify_fun, VerifyFun}],
+                       {partial_chain, fun partial_chain/1}, {verify_fun, VerifyFun},
+                       {middlebox_comp_mode, false}],
             check_hostname_opt(SslOpts);
         false ->
             ?WARN("Insecure HTTPS request (peer verification disabled), "


### PR DESCRIPTION
This is to unblock builds on OTP 24.

see erlang/otp#8470 and elixir-lang/elixir#14356

also see #24 and #25